### PR TITLE
Only restore selection if editor has focus

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -63,14 +63,14 @@ var QuillMixin = {
 	*/
 	setEditorContents: function(editor, value) {
 		var sel = editor.getSelection();
-		
+
 		if (typeof value === 'string') {
 			editor.clipboard.dangerouslyPasteHTML(value);
 		} else {
 			editor.setContents(value);
 		}
 
-		if (sel) this.setEditorSelection(editor, sel);
+		if (sel && editor.hasFocus()) this.setEditorSelection(editor, sel);
 	},
 
 	setEditorSelection: function(editor, range) {


### PR DESCRIPTION
in `setEditorContents`. Prevents component from stealing focus if content changes when the editor isn't focused